### PR TITLE
Avoid window not defined error

### DIFF
--- a/src/RSA.js
+++ b/src/RSA.js
@@ -1,3 +1,6 @@
+global.window = {};
+global.document = {};
+global.navigator = { userAgent: '' };
 const { JSEncrypt } = require("jsencrypt");
 
 @registerDynamicValueClass // eslint-disable-line


### PR DESCRIPTION
`jsencrypt` needs a window object to work, this defines an emtpy object so it can work